### PR TITLE
Upgrade json-refs dependency - fixes #6

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "json-refs": "^1.0.0",
-    "yaml-js": "^0.1.1"
+    "json-refs": "^2.0.3",
+    "yaml-js": "^0.1.3"
   }
 }

--- a/resolve.js
+++ b/resolve.js
@@ -4,8 +4,11 @@ var fs = require('fs');
 
 var root = YAML.load(fs.readFileSync('index.yaml').toString());
 var options = {
-  processContent: function (content) {
-    return YAML.load(content);
+  filter        : ['relative', 'remote'],
+  loaderOptions : {
+    processContent : function (res, callback) {
+      callback(null, YAML.load(res.text));
+    }
   }
 };
 resolve(root, options).then(function (results) {


### PR DESCRIPTION
> adapt to the breaking changes in json-refs API

There were a couple of breaking changes introduced in v2.0.0 in `json-refs` as detailed [here](https://github.com/whitlockjc/json-refs/blob/master/RELEASE_NOTES.md#v200-2016-01-06).

The `options.processContent` callback needs to be nested as `options.loaderOptions.processContent` as there is a new module ([`path-loader`](https://github.com/whitlockjc/path-loader)) that is doing the content loading and also, it has a new signature to enable asynchronous processing of content done by a callback that needs to be called (details are at https://github.com/whitlockjc/path-loader/issues/7).

Another new option that is added (`filter        : ['relative', 'remote']`) enables retaining the local references (like the `schema` for `200` within `responses` below - which is retained as `"$ref": "#/definitions/User"`), since it is a local reference that is not supplied in the filter (details about the `filter` option is [here](https://github.com/whitlockjc/json-refs/blob/master/docs/API.md#jsonrefsjsonrefsoptions--object)).

Below is how the result now looks with the updated code and dependencies:  

```json
{
  "swagger": "2.0",
  "info": {
    "version": "0.0.0",
    "title": "Simple API"
  },
  "paths": {
    "/foo": {
      "get": {
        "responses": {
          "200": {
            "description": "OK"
          }
        }
      }
    },
    "/bar": {
      "get": {
        "responses": {
          "200": {
            "description": "OK",
            "schema": {
              "$ref": "#/definitions/User"
            }
          }
        }
      }
    }
  },
  "definitions": {
    "User": {
      "type": "object",
      "properties": {
        "name": {
          "type": "string"
        }
      }
    }
  }
}
```